### PR TITLE
Modify force-push permissions for code-playground (testing repository sync)

### DIFF
--- a/otterdog/eclipse-sealman.jsonnet
+++ b/otterdog/eclipse-sealman.jsonnet
@@ -76,6 +76,9 @@ orgs.newOrg('technology.sealman', 'eclipse-sealman') {
           pattern: "main",
           allows_deletions: false,
           allows_force_pushes: false,
+          bypass_force_push_allowances: [
+            "@gk-welotec",
+          ],
           blocks_creations: false,
           requires_pull_request: true,
           required_approving_review_count: 1,


### PR DESCRIPTION
We would like to maintain a private GitLab repository as the main development and integration hub, while open-sourcing one directory (using git subtree split) to a public GitHub repository.
To synchronize the two repositories, we need one technical user with permission (PAT) to force-push to the main branch of the public GitHub repository.
This account would be used only for automated synchronization:
- Pull incoming commits from the public (open-source) repository into our private GitLab monorepo.
- Build and test those changes in our internal CI/CD pipeline (including integration and functional tests).
- If all tests pass, approve and mirror the validated commits back to the public repository.
This setup ensures that all external contributions are verified in our controlled environment before being merged upstream, keeping both repositories synchronized and tested. 
In this repository we still work with a non-technical user: my personal one, but in the "productive" repository this will be changed.